### PR TITLE
Add missing include of climits for CHAR_BIT.

### DIFF
--- a/searching.hpp
+++ b/searching.hpp
@@ -12,6 +12,7 @@
 #include <unordered_map>
 #include <cassert>
 #include <type_traits>
+#include <climits>
 
 namespace tba {
 


### PR DESCRIPTION
`CHAR_BIT` is defined in `<climits>`, so I guess it might compile for some people without including it, but not for me.
